### PR TITLE
Clear file browser input after upload

### DIFF
--- a/scripts/filemanager.js
+++ b/scripts/filemanager.js
@@ -907,6 +907,9 @@ $(function(){
 			}
 			$('#upload').removeAttr('disabled');
 			$('#upload span').removeClass('loading').text(lg.upload);
+			
+			// clear data in browse input
+                	$("#newfile").replaceWith('<input id="newfile" type="file" name="newfile">');
 		}
 	});
 


### PR DESCRIPTION
No the filepath stays visible after uploadingm, why not clear it after upload :)
