### PR TITLE
Set file manager config parameters from outside

### DIFF
--- a/scripts/filemanager.config.js.default
+++ b/scripts/filemanager.config.js.default
@@ -2,6 +2,8 @@
   Configuration
 ---------------------------------------------------------*/
 
+var urlVars = getUrlVars();
+
 // Set culture to display localized messages
 var culture = 'en';
 
@@ -21,16 +23,35 @@ var browseOnly = false;
 // Set this to the server side language you wish to use.
 var lang = 'php'; // options: php, jsp, lasso, asp, cfm, ashx, asp // we are looking for contributors for lasso, python connectors (partially developed)
 
+// Sets paths to connectors based on language selection.
+var fileConnector =  urlVars["connectorUrl"] ?  decodeURIComponent(urlVars["connectorUrl"]) : 'connectors/' + lang + '/filemanager.' + lang;
+
 var am = document.location.pathname.substring(1, document.location.pathname.lastIndexOf('/') + 1);
 
 // Set this to the directory you wish to manage.
-var fileRoot = '/' + am + 'userfiles/';
+var fileRoot = urlVars["fileRoot"] ?  decodeURIComponent(urlVars["fileRoot"]) : '/' + am + 'userfiles/';
 
 //Path to the manage directory on the HTTP server
-var relPath = window.location.protocol + '//' + document.domain;
+var relPath = urlVars["relPath"] ? decodeURIComponent(urlVars["relPath"]) : window.location.protocol + '//' + document.domain;
 
 // Show image previews in grid views?
 var showThumbs = true;
 
 // Allowed image extensions when type is 'image'
 var imagesExt = ['jpg', 'jpeg', 'gif', 'png'];
+
+// gets array of supplied URL parameters
+function getUrlVars()
+{
+	var vars = [], hash;
+	var hashes = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&');
+	
+	for(var i = 0; i < hashes.length; i++)
+	{
+		hash = hashes[i].split('=');
+		vars.push(hash[0]);
+		vars[hash[0]] = hash[1];
+	}
+	
+	return vars;
+}

--- a/scripts/filemanager.js
+++ b/scripts/filemanager.js
@@ -24,9 +24,6 @@ $.urlParam = function(name){
   Setup, Layout, and Status Functions
 ---------------------------------------------------------*/
 
-// Sets paths to connectors based on language selection.
-var fileConnector = 'connectors/' + lang + '/filemanager.' + lang;
-
 var capabilities = new Array('select', 'download', 'rename', 'delete');
 
 // Get localized messages from file 


### PR DESCRIPTION
I made a few changes in order to be able to set file manager config params from external code.

Use case: in my project I use CKEditor for different modules that are completely isolated from each other. Obviously, these modules use different file storage behind. Unfortunately, initial version of FileManager plugin forced me to use single file storage and didn't provide any configuration options. So, I had to modify the code and now want to share it with community.

How to use it: specify URL params when create and URL for FileManager index.html page like:
ckeditor/plugins/filemanager/index.html?relPath=http://mysite.com/blah/blah/blah&connectorUrl=http://mysite.com/connector/blah/blah/connector.ashx

If you have any questions or suggestions, please notify me.

br,
Vova
