### PR TITLE
Fixing issue #156 where Chrome overlays columns.

### DIFF
--- a/scripts/filemanager.js
+++ b/scripts/filemanager.js
@@ -1054,11 +1054,7 @@ $(function(){
 	} else {
 		expandedFolder = '';
 		fullexpandedFolder = null;
-	}
-	
-	// Adjust layout.
-	setDimensions();
-	$(window).resize(setDimensions);
+        }
 
 	// we finalize the FileManager UI initialization 
 	// with localized text if necessary
@@ -1087,11 +1083,6 @@ $(function(){
 	} else {
 		$('#search').remove();
 	}
-
-	// Provides support for adjustible columns.
-	$('#splitter').splitter({
-		sizeLeft: 200
-	});
 
 	// cosmetic tweak for buttons
 	$('button').wrapInner('<span></span>');
@@ -1206,6 +1197,15 @@ $(function(){
 		$('.contextMenu .rename').remove();
 		$('.contextMenu .delete').remove();
 	}
+        
+        // Adjust layout.
+	setDimensions();
+	$(window).resize(setDimensions);
+        
+        // Provides support for adjustible columns.
+	$('#splitter').splitter({
+		sizeLeft: 200
+	});
     getDetailView(fileRoot + expandedFolder);
 });
 


### PR DESCRIPTION
Fixing issue #156 where Chrome overlays columns.  Looks like it is a race condition of the window getting setup and the Javascript running.  By moving setDemensions and splitter calls to the bottom of the initialization function seems to fix this. Works in firefox, chrome and safari.
