### PR TITLE
Support for appending fileRoot in url

### DIFF
--- a/scripts/filemanager.js
+++ b/scripts/filemanager.js
@@ -477,12 +477,12 @@ var createFileTree = function() {
 // contextual menu option in list views. 
 // NOTE: closes the window when finished.
 var selectItem = function(data) {
-	if(config.options.relPath != false ) {
+	if(config.options.relPath !== false ) {
 		var url = relPath + data['Path'].replace(fileRoot,""); 
 	} else {
 		var url = relPath + data['Path'];
 	}
-    
+
 	if(window.opener || window.tinyMCEPopup || $.urlParam('field_name')){
 	 	if(window.tinyMCEPopup){
         	// use TinyMCE > 3.0 integration method
@@ -1159,7 +1159,11 @@ $(function(){
 	} else {
 		relPath = config.options.relPath;
 	}
-	
+
+	if($.urlParam('fileRoot') != 0) {
+		fileRoot += $.urlParam('fileRoot');
+		fileRoot = fileRoot.replace(/\/\//g, '\/');
+	}
 
 	if($.urlParam('expandedFolder') != 0) {
 		expandedFolder = $.urlParam('expandedFolder');
@@ -1167,7 +1171,7 @@ $(function(){
 	} else {
 		expandedFolder = '';
 		fullexpandedFolder = null;
-        }
+	}
 
 	// we finalize the FileManager UI initialization 
 	// with localized text if necessary


### PR DESCRIPTION
This is similar to "expandedFolder" parameter in URL, but it makes such folder as "root".

Use case:
We can have root folder "uploads/", which contains folders "files", "images", "videos"
Then we can work only with "videos", so we can use in url "?fileRoot=videos/" and we will see only content of that folder  + when we choose some file, we could get relative path.

Btw change on line #480 (from !=  to  !==) is required to allow empty relPath - I think this should be fixed anyway :)
