### PR TITLE
added a downloadRedirect option to send only a link to the download-file

### DIFF
--- a/connectors/php/filemanager.class.php
+++ b/connectors/php/filemanager.class.php
@@ -630,14 +630,25 @@ class Filemanager {
 		}
 
 		if(isset($this->get['path']) && file_exists($current_path)) {
-			header("Content-type: application/force-download");
-			header('Content-Disposition: inline; filename="' . basename($current_path) . '"');
-			header("Content-Transfer-Encoding: Binary");
-			header("Content-length: ".filesize($current_path));
-			header('Content-Type: application/octet-stream');
-			header('Content-Disposition: attachment; filename="' . basename($current_path) . '"');
-			readfile($current_path);
-			$this->__log(__METHOD__ . ' - downloading '. $current_path);
+			$redirect = $this->config['options']['downloadRedirect'];
+			if($redirect) {
+				$rel_file = preg_replace( $redirect, "/", $current_path );
+				$response = "<html><head><meta http-equiv='refresh' content='1; ".$rel_file."' /></head></html>";
+				header("Content-type: text/html");
+				header("Content-length: ". strlen( $response ) );
+				echo $response;
+				$this->__log(__METHOD__ . ' - downloading through redirect'. $current_path);
+			} else {
+				header("Content-type: application/force-download");
+				header('Content-Disposition: inline; filename="' . basename($current_path) . '"');
+				header("Content-Transfer-Encoding: Binary");
+				header("Content-length: ".filesize($current_path));
+				header('Content-Type: application/octet-stream');
+				header('Content-Disposition: attachment; filename="' . basename($current_path) . '"');
+				readfile($current_path);
+
+				$this->__log(__METHOD__ . ' - downloading '. $current_path);
+			}
 			exit();
 		} else {
 			$this->error(sprintf($this->lang('FILE_DOES_NOT_EXIST'),$current_path));

--- a/scripts/filemanager.config.js.default
+++ b/scripts/filemanager.config.js.default
@@ -19,6 +19,7 @@
         "serverRoot": true,
         "fileRoot": false,
         "relPath": false,
+        "downloadRedirect": false,
         "logger": false,
         "capabilities": ["select", "download", "rename", "move", "delete", "replace"],
         "plugins": []


### PR DESCRIPTION
A simple hack for being able to download long files without having to increase the php-memory-limit. Set

```
downloadRedirect
```

to a regular expression (like "/^.srv.http./" for ArchLinux) that will be used to replace the file-path of the download-link. Instead of sending the file, it only sends a redirect-html-request that points to the file.

If downloadRedirect is false, it behaves as before and tries to send the file directly.

I'm sure the serverRoot or fileRoot could be used for this, too...
