### PR TITLE
Closing window in TinyMCE 4

### DIFF
--- a/scripts/filemanager.js
+++ b/scripts/filemanager.js
@@ -522,9 +522,8 @@ var selectItem = function(data) {
 	 	if($.urlParam('field_name')){
 	 		parent.document.getElementById($.urlParam('field_name')).value = url;
 	 		
-	 		if(typeof top.tinyMCE !== "undefined") {
-	 			// parent.tinyMCE.activeEditor.windowManager.close(); it seems parent. does not work with IE9 /IE10
-		 		top.tinyMCE.activeEditor.windowManager.close();
+	 		if(typeof parent.tinyMCE !== "undefined") {
+		 		parent.tinyMCE.activeEditor.windowManager.close();
 		 	}
 		 	if(typeof parent.$.fn.colorbox !== "undefined") {
 		 		parent.$.fn.colorbox.close();


### PR DESCRIPTION
I'm proposing this be reverted to "parent", unless it can be confirmed that it still doesn't work in IE9-IE10 (it worked in all my tests).  If there is still a problem with parent, then I think it should try both top and parent to support cases where TinyMCE is in a frame.
