### PR TITLE
Filetypes checked case insensitive

### DIFF
--- a/connectors/php/filemanager.class.php
+++ b/connectors/php/filemanager.class.php
@@ -903,12 +903,12 @@ private function isAllowedFileType($file) {
 	
 	if($this->config['security']['uploadPolicy'] == 'DISALLOW_ALL') {
 			
-		if(!in_array($path_parts['extension'], $this->config['security']['uploadRestrictions']))
+		if(!in_array(strtolower($path_parts['extension']), $this->config['security']['uploadRestrictions']))
 			$this->error(sprintf($this->lang('INVALID_FILE_TYPE')),true);
 	}
 	if($this->config['security']['uploadPolicy'] == 'ALLOW_ALL') {
 	
-		if(in_array($path_parts['extension'], $this->config['security']['uploadRestrictions']))
+		if(in_array(strtolower($path_parts['extension']), $this->config['security']['uploadRestrictions']))
 			$this->error(sprintf($this->lang('INVALID_FILE_TYPE')),true);
 	}
 	


### PR DESCRIPTION
Case sensitive filetype checking in php connector forced filemanager.config.js extension list to include all possible combinations of upper and lowercase characters.
