### PR TITLE
Fixed file selection with TinyMCE 4.

### DIFF
--- a/scripts/filemanager.js
+++ b/scripts/filemanager.js
@@ -559,7 +559,7 @@ var selectItem = function(data) {
 		var url = relPath + data['Path'];
 	}
     
-	if(window.opener || window.tinyMCEPopup || $.urlParam('CKEditorCleanUpFuncNum') || $.urlParam('CKEditor')) {
+	if(window.opener || window.tinyMCEPopup || $.urlParam('field_name') || $.urlParam('CKEditorCleanUpFuncNum') || $.urlParam('CKEditor')) {
 	 	if(window.tinyMCEPopup){
         	// use TinyMCE > 3.0 integration method
             var win = tinyMCEPopup.getWindowArg("window");


### PR DESCRIPTION
Without checking for 'field_name' we just fall through to
$.prompt(lg.fck_select_integration) on clicking 'Select'.
