### PR TITLE
Update config setup to be friendlier when using Filemanager as part of another project

### DIFF
--- a/config/filemanager.config.json
+++ b/config/filemanager.config.json
@@ -26,7 +26,8 @@
         "relPath": false,
         "logger": false,
         "capabilities": ["select", "download", "rename", "delete", "replace"],
-        "plugins": []
+        "plugins": [],
+        "userConfigOnly": true
     },
     "security": {
         "allowChangeExtensions": false,

--- a/connectors/php/filemanager.class.php
+++ b/connectors/php/filemanager.class.php
@@ -39,6 +39,12 @@ class Filemanager {
 		$content = file_get_contents($this->root . 'config/filemanager.config.json');
 		$this->config = json_decode($content, true);
 
+		if( !$this->config['options']['userConfigOnly'] ) {
+			$content = file_get_contents($this->root . 'scripts/filemanager.config.js.default');
+			$defaults = json_decode($content, true);
+			$this->config = array_replace_recursive($defaults, $this->config);
+		}
+
 		// override config options if needed
 		if(!empty($extraConfig)) {
 			$this->setup($extraConfig);

--- a/scripts/filemanager.js
+++ b/scripts/filemanager.js
@@ -26,17 +26,30 @@ $.urlParam = function(name){
 
 // We retrieve config settings from filemanager.config.js
 var loadConfigFile = function (type) {
-	var json = null;
-	var url = 'config/filemanager.config.json';
+	var config = null;
+
     $.ajax({
         'async': false,
-        'url': url,
+        'url': 'config/filemanager.config.json',
         'dataType': "json",
         'success': function (data) {
-            json = data;
+            config = data;
         }
     });
-    return json;
+
+    if(!config.options.userConfigOnly) { 
+    	$.ajax({
+	        'async': false,
+	        'url': 'scripts/filemanager.config.js.default',
+	        'dataType': "json",
+	        'success': function (data) {
+	            defaults = data;
+	        }
+	    });
+	    config = $.extend({}, defaults, config);
+    }
+
+    return config;
 };
 
 // loading user configuration file


### PR DESCRIPTION
I'm primarily using Filemanager as an extension at work so I'm interested in seeing the front-end and back-end modularized, and being able to function independently of each other. Here are the main things I did to decouple them for my project.
1. The config file is shared between front-end and back-end so I moved it into a config/ folder for ease of management. 
2. Paths to Filemanager's internal files set by `__DIR__` to support having Filemanager root folder be in side another project's vendor/ folder. This makes it compatible to be dropped into another project, and follow many popular framework naming convention
3. The config file has options related to paths to different places broken off into its own JSON property for ease of reading.

The code so far has been focusing on the back-end. I will submit another pull request for front-end changes.
I've also done refactoring of the getfolder() to make it easier to read while I was studying the code as well.

Thank you for your work. I appreciate this project very much.
