### PR TITLE
Quick fix to allow path names that contain the separator twice in a path

### DIFF
--- a/connectors/php/filemanager.class.php
+++ b/connectors/php/filemanager.class.php
@@ -1282,8 +1282,10 @@ private function has_permission($action) {
  * @param string $path
  */
 private function get_thumbnail_path($path) {
-		
-	$a = explode($this->separator, $path);
+	
+	$pos = strrpos($path, $this->separator);
+	$a[0] = substr($path,0,$pos);
+	$a[1] = substr($path,$pos+strlen($this->separator));
 
 	$path_parts = pathinfo($path);
 


### PR DESCRIPTION
I had a case where my "separator" appeared twice in my path.  For example given a rootPath of:

/var/www/site/public/uploads/www/ 

This caused FileManager to try and make my _thumb directory at /var/www/_thumbs which it didn't have permission to do.  I tried to keep the result in the same format as before.