### PR TITLE
Remove unused option maxuploadfilesize

### DIFF
--- a/connectors/php/filemanager.php
+++ b/connectors/php/filemanager.php
@@ -106,10 +106,6 @@ if(!isset($_GET)) {
           $fm->preview($thumbnail);
         }
         break;
-			
-      case 'maxuploadfilesize':
-        $fm->getMaxUploadFileSize();
-        break;
     }
 
   } else if(isset($_POST['mode']) && $_POST['mode']!='') {

--- a/index.html
+++ b/index.html
@@ -1,5 +1,4 @@
-﻿
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />

--- a/index.html
+++ b/index.html
@@ -1,4 +1,5 @@
-﻿<!DOCTYPE html>
+﻿
+<!DOCTYPE html>
 <html>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />


### PR DESCRIPTION
i search the option "maxuploadfilesize" on javascript-side and this option is never called. 
than we can delete this, because this is unused