### PR TITLE
Fix invalid directory comparison

### DIFF
--- a/connectors/php/filemanager.class.php
+++ b/connectors/php/filemanager.class.php
@@ -1167,9 +1167,7 @@ private function is_valid_path($path) {
 	$this->__log('substr path_to_files : ' . substr(realpath($path) . DIRECTORY_SEPARATOR, 0, strlen($this->path_to_files)));
 	$this->__log('path_to_files : ' . realpath($this->path_to_files) . DIRECTORY_SEPARATOR);
 	
-	return substr(realpath($path) . DIRECTORY_SEPARATOR, 0, strlen($this->path_to_files)) == (realpath($this->path_to_files) . DIRECTORY_SEPARATOR);
-	
-	
+	return substr(realpath($path) . DIRECTORY_SEPARATOR, 0, strlen(realpath($this->path_to_files) . DIRECTORY_SEPARATOR)) == (realpath($this->path_to_files) . DIRECTORY_SEPARATOR);
 }
 
 private function unlinkRecursive($dir,$deleteRootToo=true) {


### PR DESCRIPTION
The comparison of $path to $this->path_to_files could never be equal because it was comparing the first strlen(realpath($this->path_to_files) characters of $path against realpath($this->path_to_files) . DIRECTORY_SEPARATOR. By adding DIRECTORY_SEPARATOR to $this->path_to_files, the second part of the comparison would always be 1 character longer.