### PR TITLE
is_valid_path fix

### DIFF
--- a/connectors/php/filemanager.class.php
+++ b/connectors/php/filemanager.class.php
@@ -1174,7 +1174,7 @@ private function is_valid_path($path) {
 	$this->__log('substr path_to_files : ' . substr(realpath($path) . DIRECTORY_SEPARATOR, 0, strlen($this->path_to_files)));
 	$this->__log('path_to_files : ' . realpath($this->path_to_files) . DIRECTORY_SEPARATOR);
 	
-	return substr(realpath($path) . DIRECTORY_SEPARATOR, 0, strlen($this->path_to_files)) == (realpath($this->path_to_files) . DIRECTORY_SEPARATOR);
+	return (substr(realpath($path) . DIRECTORY_SEPARATOR, 0, strlen(realpath($this->path_to_files))) . DIRECTORY_SEPARATOR) == (realpath($this->path_to_files) . DIRECTORY_SEPARATOR);
 	
 	
 }


### PR DESCRIPTION
With options:

     {
         "serverRoot": true,
         "fileRoot": "user_files/",
         "baseUrl": false
     }

browsing sub-folders fails with an "No way.".

Logging `is_valid_path` it turns out that `strlen($this->path_to_files)` returns a "wrong" length because of the trailing "/" in fileRoot.

This patch fixes this.