### PR TITLE
Fix plugin height for case the page include other DOM elements

### DIFF
--- a/connectors/php/filemanager.class.php
+++ b/connectors/php/filemanager.class.php
@@ -446,7 +446,17 @@ class Filemanager {
 			} else {
 				$this->error(sprintf($this->lang('ERROR_RENAMING_FILE'),$filename,$this->get['new']));
 			}
-		}
+        	} else {
+            		// For image only - rename thumbnail if original image was successfully renamed
+            		if(!is_dir($new_file) && $this->is_image($new_file)) {
+                		$new_thumbnail = $this->get_thumbnail_path($new_file);
+                		$old_thumbnail = $this->get_thumbnail_path($old_file);
+                		if(file_exists($old_thumbnail)) {
+                    			rename($old_thumbnail, $new_thumbnail);
+                		}
+            		}
+        	}
+        	
 		$array = array(
 				'Error'=>"",
 				'Code'=>0,

--- a/scripts/filemanager.js
+++ b/scripts/filemanager.js
@@ -158,14 +158,15 @@ $.prompt.setDefaults({
 // Forces columns to fill the layout vertically.
 // Called on initial page load and on resize.
 var setDimensions = function(){
-	var bheight = 53;
-	
+	var bheight = 53,
+		$uploader = $('#uploader');
+
 	if($.urlParam('CKEditorCleanUpFuncNum')) bheight +=60;
 
-	var newH = $(window).height() - $('#uploader').height() - bheight;	
+	var newH = $(window).height() - $uploader.height() - $uploader.offset().top - bheight;
 	$('#splitter, #filetree, #fileinfo, .vsplitbar').height(newH);
 	var newW = $('#splitter').width() - $('div.vsplitbar').width() - $('#filetree').width();
-    $('#fileinfo').width(newW);
+	$('#fileinfo').width(newW);
 };
 
 // Display Min Path


### PR DESCRIPTION
I have placed the filemanager on page that have header DOM element.
The height of the header is 80px, and it shifts the filemanager down, so it looks as: http://i.imgur.com/hl6Ahdw.png

You can see the filemanager is overlapped.
Current PR created to respect the height of DOM elements which are positioned above the filemanager, look the result with PR: http://i.imgur.com/HadmjXx.png

To your notice: It might be a good idea to wrap the whole filemanager template in a container like `<div class="fm-container">` and calculate offset base on it, and not on `#uploader` as I have implemented. I guess it  will be more reliable, because one might change the template and change position of `#uploader`.

I haven't tested it for different devices or browsers.