### PR TITLE
Added the proper trailing slash to the route for the connector.  This…

### DIFF
--- a/scripts/filemanager.js
+++ b/scripts/filemanager.js
@@ -120,7 +120,7 @@ smartPath = function(url, path) {
 };
 
 // Sets paths to connectors based on language selection.
-var fileConnector = config.options.fileConnector || 'connectors/' + config.options.lang + '/filemanager.' + config.options.lang;
+var fileConnector = config.options.fileConnector || 'connectors/' + config.options.lang + '/filemanager.' + config.options.lang + '/';
 
 // Read capabilities from config files if exists
 // else apply default settings


### PR DESCRIPTION
… results in

http://localhost:60687/Scripts/filemanager/connectors/mvc/filemanager.mvc/?path=%2FScripts%2Ffilemanager%2Fuserfiles%2F&config=filemanager.config.js&mode=getfolder&showThumbs=true&time=27

instead of

http://localhost:60687/Scripts/filemanager/connectors/mvc/filemanager.mvc?path=%2FScripts%2Ffilemanager%2Fuserfiles%2F&config=filemanager.config.js&mode=getfolder&showThumbs=true&time=27

This is very important for ASP.Net as it strictly enforces url routes to not be filenames.  The only way's arround this are to hack the http handlers, or fix the url so it is proper.  For details on the issue see

http://stackoverflow.com/questions/11728846/dots-in-url-causes-404-with-asp-net-mvc-and-iis